### PR TITLE
README: Refer to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# sca-drachenwald.gitlab.io
+# drachenwald
 
-This is the source code for the website of the Kingdom of Drachenwald in the Society for Creative Anachronism. You are welcome to submit changes as merge requests through Gitlab. For individual pages, this can be done through the Gitlab interface. If you would like to make more substantial changes, follow these instructions to get a local copy of the code, build the website on your machine, and submit changes back.
+This is the source code for the website of the Kingdom of Drachenwald in the Society for Creative Anachronism. You are welcome to submit changes as pull requests through GitHub. For individual pages, this can be done through the GitHub interface. If you would like to make more substantial changes, follow these instructions to get a local copy of the code, build the website on your machine, and submit changes back.
 
 Overview for the internet-uninitiated, with some terminology
 ======================
 
-The web artificers store the site content in [GitLab][], and use [Git][], a version-control software, to download copies to their local machines, work on the content, view/test new content on their machines, then save them back to GitLab. 
+The web artificers store the site content in [GitHub][], and use [Git][], a version-control software, to download copies to their local machines, work on the content, view/test new content on their machines, then save them back to GitHub.
 
-The GitLab account and storage is free. A condition of free accounts is that they are public and open source - anyone can search for the content and view it, code and all. Anyone with a GitLab account can submit changes or edits. The web artificers control the final published changes, to prevent malicious changes.
+The GitHub account and storage is free. A condition of free accounts is that they are public and open source - anyone can search for the content and view it, code and all. Anyone with a GitHub account can submit changes or edits. The web artificers control the final published changes, to prevent malicious changes.
 
 Web artificers work on the content itself (the words) using source code editors. 
 The text is written using [Markdown] conventions, and saved as text files with .md suffix. Markdown is almost like writing email in plain text. 
@@ -22,7 +22,7 @@ The web artificers are using a theme designed for Jekyll called [Minimal Mistake
 
 Contributing at the 'code-face' requires time to download and install software, learn how to use it, and learn the order of publishing events (called the workflow). There are many guides, tutorials and cheatsheets available to help. Not to mention Pelicans.
 
-[Gitlab]: https://gitlab.com/
+[GitHub]: https://github.com/
 [Git]: https://git-scm.com/
 [Ruby]: https://www.ruby-lang.org/en/
 [Jekyll]: https://jekyllrb.com/
@@ -65,18 +65,18 @@ If you have not used Jekyll before, [see the Jekyll website for a ground-up intr
 * You create content: mainly text in Markdown. 
 * Add images or data. 
 * Save content in appropriate folders.  
-* Commit (and push) the content to GitLab, using Git commands
+* Commit (and push) the content to GitHub, using Git commands
 * Run Jekyll from the command line.  
 
 Jekyll creates the HTML versions of the pages, following the instructions in the theme to provide the layout, formatting and navigation. **You don't need to edit any HTML manually.**
 - - - - -
 
-Set yourself up on GitLab with an SSH key
+Set yourself up on GitHub with an SSH key
 =========================
 
-Set up an account on [GitLab](https://gitlab.com/).
+Set up an account on [GitHub][].
 
-Create an SSH key and add the public key to your GitLab profile. [Instructions on GitLab.](https://docs.gitlab.com/ee/ssh/)
+Create an SSH key and add the public key to your GitHub profile. [Instructions on GitHub.](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
 
 Choose an editor to view and edit the content of the site
@@ -85,7 +85,7 @@ Choose an editor to view and edit the content of the site
 
 **Visual Studio Code** is slightly whizzier, and helps you work through some of the downloading and uploading steps in Git as well. [Download Visual Studio code](https://code.visualstudio.com/)
 
-You now have all the tools to start copying the site from GitLab, and editing it on your own machine.
+You now have all the tools to start copying the site from GitHub, and editing it on your own machine.
 
 Get your clone of the website
 =============================
@@ -94,14 +94,14 @@ Get your clone of the website
 
 **macOS:** Open a terminal window.
 
-Go to the [project page on GitLab](https://gitlab.com/sca-drachenwald/sca-drachenwald.gitlab.io). Click on "Clone" and copy the link for "Clone with SSH".
+Go to the [project page on GitHub](https://github.com/drachenwald/drachenwald). Click on the "Code" button, and see the "Local" tab in that box, and copy the link for "SSH".
 
 In your command line window, run:
 
 ```
-git clone git@gitlab.com:sca-drachenwald/sca-drachenwald.gitlab.io.git
+git clone git@github.com:drachenwald/drachenwald.git
 
-cd sca-drachenwald
+cd drachenwald
 ```
 
 Start the Jekyll development server
@@ -134,7 +134,7 @@ __NOTE: When you're editting the site, ignore the _site directory, this director
 
 __NOTE: All your filenames must use lower case only.__ Mixed case filenames introduce errors in systems that are case sensitive. Avoid entirely by using only lower case.
 
-To get the latest changes from GitLab:
+To get the latest changes from GitHub:
 
 ```
 git pull
@@ -147,7 +147,7 @@ git branch <branch name>
 git checkout <branch name>
 ```
 
-When you make changes, to commit them and push them to GitLab:
+When you make changes, to commit them and push them to GitHub:
 
 ```
 git add .
@@ -155,7 +155,7 @@ git commit -m "<message for the git log>"
 git push
 ```
 
-Once you've pushed changes in your own branch, go to GitLab and create a Merge Request (this is an item in the sidebar menu.)
+Once you've pushed changes in your own branch, go to GitHub and create a Pull Request (there will be a button).
 
 If you keep using the same branch for future changes, bring it up to date with the staging branch by frequently running:
 
@@ -174,7 +174,7 @@ Conventions
 
 Git References
 ============
-* [GitLab's command-line cheatsheet, if you haven't used command lines before](https://gitlab.com/help/gitlab-basics/command-line-commands.md)
+* [GitHub's "Get Started" documentation](https://docs.github.com/get-started)
 * [Git's own documentation](https://git-scm.com/book/en/v2)
 * [Another cheat sheet for Git commands](https://git-scm.com/docs/giteveryday)
 * [Git the simple guide](https://rogerdudler.github.io/git-guide/)
@@ -192,7 +192,7 @@ At home, this requirement meant installing Ruby on C:\ drive, the same 'level' a
 At work, where I don't have permissions to add or change anything on my C:\ drive, it meant installing Ruby at the highest 'level' within my user profile.
 
 ## Installing Jekyll gems
-Each Git directory (aka repository, containing website content) requires *its own set of gems*, including the Jekyll-related ones that generate the site. So for example, if you are working both on the Drachenwald website, and a shire website, both stored on GitLab, you need to install the Jekyll bundle once in each directory.
+Each Git directory (aka repository, containing website content) requires *its own set of gems*, including the Jekyll-related ones that generate the site. So for example, if you are working both on the Drachenwald website, and a shire website, both stored on GitHub, you need to install the Jekyll bundle once in each directory.
 
 This is a *different location* from where you install Ruby.
 
@@ -223,12 +223,12 @@ You saved your content, added it, committed it, and pushed it. You run 'bundle e
 `Liquid Exception: Could not find document 'offices/herald/drachenwaldawardsorders.md' in tag 'link'. Make sure the document exists and the path is correct. in heraldsbeforetheinternet.md`
 
 Check: which directory are you in? You can only run Jekyll from the 'top' of the directory for your site, so for the Drachenwald website it's 
-` $ `[your_directories_path`]/git/sca-drachenwald.gitlab.io`>
+` $ `[your_directories_path`]/git/drachenwald`>
 
 ## Jekyll doesn't build and throws an error, with a filename, a line and column location of the error
 
 ~~~~
-YAML Exception reading C:/Users/eabrown/git/sca-drachenwald.gitlab.io/offices/herald/zenofgoodcourtguidance.md: (<unknown>): mapping values are not allowed in this context at line 2 column 29
+YAML Exception reading C:/Users/eabrown/git/drachenwald/offices/herald/zenofgoodcourtguidance.md: (<unknown>): mapping values are not allowed in this context at line 2 column 29
 ~~~~~~~
 Jekyll is picky about the syntax that tells it what is text, and what is an instruction. 
 


### PR DESCRIPTION
This changes links, and in some cases, GitHub language, and some references to its UI.

- Pull Request
- Code button (to get the git:// URI)
- Paths referring to the gitlab setup

<details>

I don't know more about any Staging environment et cetera. So, I didn't go further than this change.

One JS include in `index.md`:

```html
<div  id="calendar"
      legend="true"
      links="local"
      bidlinks="true"
></div>
<script type="text/javascript" src="https://sca-drachenwald.gitlab.io/events-calendar/calendar.js"></script>
```

</details>