### PR TITLE
Configure a dependabot.yml to update the GitHub Actions, weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This adds an automatic update-by-PR GitHub feature, so that GitHub Actions versions for things like `actions/checkout@v3` are kept up to date automatically.