### PR TITLE
Remove reference to the defunct Announcement mailman list

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@ feature_row:
 
 <p style="text-align: center;">
   <a href="https://www.facebook.com/groups/2849266042" class="btn btn--primary"><i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i> Follow us on Facebook</a>
-  <a href="http://lists.drachenwald.sca.org/mailman/listinfo/announcements" class="btn btn--primary"><i class="fas fa-fw fa-envelope" aria-hidden="true"></i> Join our announcements list</a>
 </p>
 
 {% assign posts = site.posts | where_exp: "item", "item.categories contains 'news'" %}


### PR DESCRIPTION
The URL http://lists.drachenwald.sca.org/mailman/listinfo/announcements points to a page with the text "This page no longer exists."

Other references not touched:
- There was an introductory reference to the Announcement list in a post from 2020, perhaps?

I saw this URL by searching for `http:` while trying to find outdated non-HTTPS links.

