### PR TITLE
Gemfile: add faraday-retry, per recommendation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "faraday", "2.7.1"
+gem "faraday-retry", "~> 2.2"
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
@@ -33,4 +34,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-


### PR DESCRIPTION
This PR adds the recommended gem [faraday-retry](https://github.com/lostisland/faraday-retry). This gets rid of a Ruby warning at startup.