### PR TITLE
Upgrade Ruby version to 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:3.2
 VOLUME ["/build"]
 WORKDIR /build
 EXPOSE 4000


### PR DESCRIPTION
This is the latest released version, a new version Ruby 3.3 is coming this December.

You can see the version string like:

    docker exec -ti drachenwald-jekyll-1 ruby --version

Application started up fine.

---

I also looked online to see if people had had any snags upgrading, and someone documented their steps to get there, and how there _was_ an incompatibility, now fixed: https://www.miskatonic.org/2023/01/02/ruby-jekyll/