### PR TITLE
Past events: avoid showing HTML comment as content

### DIFF
--- a/events/pastevents.md
+++ b/events/pastevents.md
@@ -23,7 +23,8 @@ Court report information is limited to those reports submitted via the court rep
 
 {% else %}
   {% assign courtreports  = "" %}
-	<!--There are no public court reports available right now-->
+<!--There are no public court reports available right now.-->
+
 {% endif %} 
 
 {% if site.data.courtreports %}

--- a/events/pastevents.md
+++ b/events/pastevents.md
@@ -6,7 +6,7 @@ The past events after 2020 are fairly reliable, but do miss the events that coun
 
 The past events from 2019 have been retrieved from the event form and are reasonably reliable, but not clear if they have been published. 
 
-The events before 2019 have been scraped from the way back machine. There is no guarantee as to it's completeness for these years nor if they have been published.
+The events before 2019 have been scraped from the way back machine. There is no guarantee as to its completeness for these years nor if they have been published.
 
 Court report information is limited to those reports submitted via the court report form.
 

--- a/events/pastevents.md
+++ b/events/pastevents.md
@@ -35,9 +35,7 @@ Court report information is limited to those reports submitted via the court rep
 	There is no information about court reports available right now
 {% endif %}
 
-
 <table>
-
   <caption><h3>Past events</h3></caption>
   
   <thead>


### PR DESCRIPTION
This fixes a small part of the issues noted in #110 - the display of an HTML comment as content.

## What it currently renders as:

<img width="762" alt="bild" src="https://github.com/drachenwald/drachenwald/assets/211/bf094075-568d-45d7-869a-1206259ac296">


## How this PR helps

<img width="739" alt="bild" src="https://github.com/drachenwald/drachenwald/assets/211/2762bb1b-ebb8-4820-9344-d6b83f05130d">
