### PR TITLE
Git Attributes file to respect binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,14 @@
 # Treat all text files without a CR (as we have Docker)
-* text eol=lf
+* text=auto
 
+*.rb text eol=lf
+*.js text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.md text eol=lf
+*.html text eol=lf
+
+# These are binary, and are not to be changed
+*.png binary
+*.jpg binary
+*.pdf binary


### PR DESCRIPTION
This PR changes the .gitattributes file to make it less intrusive, it no longer wishes to edit PDFs and other binary files.

I listed file types until the Git checkout began not to edit the PDFs.

Learn more about Git Attributes file:
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings