### PR TITLE
Each link to a Tag ends with a slash

### DIFF
--- a/_layouts/autopage_artsci_tags.html
+++ b/_layouts/autopage_artsci_tags.html
@@ -10,9 +10,9 @@ pagination:
 {% for post in paginator.posts %}
   <p>
   <strong><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></strong> {{ post.date | date:"%Y-%m-%d" }}<br>
-  
+
   {% for tag in post.tags %}
-  <a href="../{{ tag }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+  <a href="../{{ tag }}/">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
   {% endfor %}
   </p>
 {% endfor %}

--- a/_layouts/autopage_cat.html
+++ b/_layouts/autopage_cat.html
@@ -6,11 +6,11 @@ pagination:
 {% for post in paginator.posts %}
   <p>
   <strong><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></strong><br>
-  
+
   {{ post.date | date:"%Y-%m-%d" }}
-  
+
   {% for tag in post.tags %}
-  <a href="{{ site.baseurl }}/posts/tags/{{ tag }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+  <a href="{{ site.baseurl }}/posts/tags/{{ tag }}/">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
   {% endfor %}
   </p>
   {{ post.excerpt }}

--- a/_layouts/autopage_tags.html
+++ b/_layouts/autopage_tags.html
@@ -6,9 +6,9 @@ pagination:
 {% for post in paginator.posts %}
   <p>
   <strong><a href="{{ site.baseurl}}{{ post.url }}">{{ post.title }}</a></strong> {{ post.date | date:"%Y-%m-%d" }}<br>
-  
+
   {% for tag in post.tags %}
-  <a href="../{{ tag }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+  <a href="../{{ tag }}/">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
   {% endfor %}
   </p>
 {% endfor %}

--- a/posts-index.html
+++ b/posts-index.html
@@ -16,7 +16,7 @@ permalink: /posts/
   </b> on  {{ post.date | date:"%Y-%m-%d" }}<br>
   
   {% for tag in post.tags %}
-    <a href="{{ site.baseurl }}/posts/tags/{{ tag }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
+    <a href="{{ site.baseurl }}/posts/tags/{{ tag }}/">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}
   {% endfor %}
   </p>
 {% endfor %}


### PR DESCRIPTION
This PR adds a slash to the end of each Tag link.

This is to try to make the site navigable from the Tag links in Posts.