### PR TITLE
Gemfile: add a gem which used to be standard library; use unreleased Jekyll which works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ VOLUME ["/build"]
 WORKDIR /build
 EXPOSE 4000
 RUN apt-get update && \
-    apt-get install -y locales && \
+    apt-get install -y locales git && \
     locale-gen en_US.UTF-8 && \
     localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LC_ALL="C.UTF-8"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "faraday-retry", "~> 2.2"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "4.3.2"
+gem "jekyll", github: "jekyll/jekyll"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minimal-mistakes-jekyll"

--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'base64' # needed from the safe_yaml gem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: 3
 services:
   jekyll:
     image: ubuntu:latest
@@ -8,4 +8,4 @@ services:
       - .:/build
     stdin_open: true
     tty: true
-    command: bash -c "apt-get update && apt-get install -y locales python3-pip ruby-full curl && gem install bundler && cd /build && bundle install && pip3 install -r _thisisdrachenwald/requirements.txt && _bin/build-local.sh && bundle exec jekyll serve --watch --host 0.0.0.0"
+    command: bash -c "apt-get update && apt-get install -y locales python3-pip ruby-full curl git && gem install bundler && cd /build && bundle install && pip3 install -r _thisisdrachenwald/requirements.txt && _bin/build-local.sh && bundle exec jekyll serve --watch --host 0.0.0.0"


### PR DESCRIPTION
This PR makes `bundle exec jekyll serve` work

- use the not-yet-released version of Jekyll - see its https://github.com/jekyll/jekyll/blob/master/History.markdown for more details ("Add support for upcoming logger 1.4.3 ([#9392](https://github.com/jekyll/jekyll/pull/9392))")
- supply a needed gem which was standard library...but is now demoted to not-always-included.

This stops warnings like

> [...]/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of safe_yaml-1.0.5 to add base64 into its gemspec.

From happening at start of the app.
