### PR TITLE
Laurel FAQ page: include Secretary email correctly

### DIFF
--- a/peers/laurel/laurel-faq.md
+++ b/peers/laurel/laurel-faq.md
@@ -78,4 +78,4 @@ No one ever joined the SCA as a Peer; everyone had to work their way up and earn
 
 The Secretaries of the Orders are listed on the Kingdom webpage and in the Newsletter; if you're too shy to ask a Peer questions in person or there are no Peers in your local area, write a letter to the Secretary of the appropriate Order. 
 
-{% include peer-secretary.html order="peers/laurel" %}
+{% include peer-secretary.html order="Drachenwald - Order of the Laurel" %}


### PR DESCRIPTION
The keys to that data had changed. I used the same settings as used on the index.md in the same directory.

In addition: I checked all inclusions of this template, and now they all do it right.

Fixes: https://github.com/drachenwald/drachenwald/issues/117

# Before this change

<img width="724" alt="image" src="https://github.com/drachenwald/drachenwald/assets/211/7f8b6478-b9c1-4d14-8c2b-1f45d3935f01">

# After this change

Fragment of the same shown:

<img width="403" alt="image" src="https://github.com/drachenwald/drachenwald/assets/211/90e429be-ed82-4b76-a119-4d415c9c7ceb">
