### PR TITLE
Webminister Tools page: summarize what Kingdom offers webministers

### DIFF
--- a/offices/webminister/index.md
+++ b/offices/webminister/index.md
@@ -35,5 +35,6 @@ Send a report to the GitHub issues tracker: [Raise a new issue](https://github.c
 ## Tools for group webministers
 
 * [Live contact information for your group]({{ site.baseurl }}{% link offices/webminister/officer-code-creator.html %})
+* [Web minister tools]({{ site.baseurl }}{% link offices/webminister/tools.md %})
 
 {% include officer-contacts.html %}

--- a/offices/webminister/tools.md
+++ b/offices/webminister/tools.md
@@ -1,0 +1,58 @@
+---
+title: Tools for webministers
+excerpt: Digital tools available to group webministers.
+
+handsfree_users:
+  - Klakavirki
+  - Glen Rathlin
+  - Pontalarch
+  - Thamesreach
+  - Mynydd Gwyn
+google_sites_users:
+  - Harpelstane
+  - KU
+  - Spring Crown 2023
+js_widgets_users:
+  - Insulaedraconis.org
+  - nordmark.org
+  - aarnimetsa.org
+  - central.drachenwald.org
+  - duninmara.org
+centralized_datafiles_users:
+  - Drachenwald.sca.org
+  - Baelfyr
+---
+
+This article presents the tools on offer for group webministers who want to use them.
+
+## Email hosting through Google Workspace
+
+The Kingdom offers email hosting on a Google Workspace. Talk to the webminister to get set up.
+
+## Handsfree website
+
+This is a JavaScript-based website where no changes are possible. This is meant to serve as an online business card for a group that does not want to do any web work themselves, it features the events for the group and presents the officers. For anything more in-depth it refers to the Insulae Draconis website. Updates happen through the regnum and event forms.
+
+The handsfree website is predominantly for groups who are small and struggling to have yet another volunteer for a website job, rather than something forced onto people. Other models exist in Nordmark, where they offer a more managed Wordpress to local groups and other kingdoms which run the gamut from managed Wordpress to entirely managed websites for local groups, or no support at all.
+
+Currently in use on {{ page.handsfree_users | array_to_sentence_string }}.
+
+## Build your own website on Google Sites using Google Workspace
+
+You can build your website on Google Sites using Google Workspace.
+
+This requires you to run email and your website through the kingdom Google Workspace. Requires a local webminister and manual updates.
+
+Currently in use by {{ page.google_sites_users | array_to_sentence_string }}.
+
+## JavaScript widgets for your website
+
+We offer JavaScript tools that present calendar & officer information that webministers can incorporate in their websites. This means information only needs to be updated in one place.
+
+Currently in use on {{ page.js_widgets_users | array_to_sentence_string }}.
+
+## Centralized datafiles for reuse
+
+The datafiles `calendar.json` & `regnum.json` are useful for webministers with advanced technical skills who want to pull information from a central repository.
+
+Currently in use on {{ page.centralized_datafiles_users | array_to_sentence_string }}.


### PR DESCRIPTION
This PR fixes #121

It adds a new article, "Tools", which has the local group webminister as its audience.

I used the "custom frontmatter" and a Liquid function to list the users of the different technologies in a easy-to-overview way.

Screenshot:

<img width="1282" alt="image" src="https://github.com/drachenwald/drachenwald/assets/211/ca12cf9c-115c-4789-9391-1a8c6179cb9c">
