### PR TITLE
Past events listing: Avoid presenting not-past events

### DIFF
--- a/events/pastevents.md
+++ b/events/pastevents.md
@@ -50,7 +50,7 @@ Court report information is limited to those reports submitted via the court rep
 {% for item in pastevents %}
 	{% assign eventslug = item.slug %}
 	{% assign event-court-status = court-status | where: "event_slug", eventslug %}
- 	   <tr>
+ 	   <tr data-start-date={{ item.start-date | date: "%s" }}>
 		<td>{{ item.start-date | date: "%-d %b %Y" }} </td>
 		<td>{{ item.host-branch }}</td>
 		<td>{{ item.event-name }}</td>
@@ -69,3 +69,16 @@ Court report information is limited to those reports submitted via the court rep
 <div style="text-align: center">
   <a href="{{ site.baseurl }}{% link events/calendar/index.md %}" class="btn btn--primary">View the calendar</a>
 </div>
+
+<script>
+(function() {
+  var rows = document.querySelectorAll("[data-start-date]")
+  var now = new Date()
+  Array.from(rows).forEach(function(r) {
+    var startDate = new Date(Number(r.dataset.startDate) * 1000)
+    if (startDate > now) {
+      r.hidden = true
+    }
+  })
+})()
+</script>


### PR DESCRIPTION
This PR changes the Past events page to **filter out too-new events**.

This makes this page more tolerant of wrong data given to it.

A JS script on the page, which knows the current date could hide not-yet-past rows!

Fixes #58 


## Screenshot after this change locally:
![image](https://github.com/drachenwald/drachenwald/assets/211/34cb12ab-c48e-4812-a18b-f5b01e63515e)

## Screenshot before this change, on the live site:
![image](https://github.com/drachenwald/drachenwald/assets/211/34056fe9-cbd5-475d-b2b3-facc89421e22)
