### PR TITLE
removal of references to yahoo groups

### DIFF
--- a/offices/archery-thrown-marshal/index.md
+++ b/offices/archery-thrown-marshal/index.md
@@ -77,7 +77,6 @@ Use a form to submit a marshal's report for your region.
 
 # Social media
 
-* [Yahoogroup](https://groups.yahoo.com/neo/groups/DW_Archery/info)
 * [Facebook Archers of Drachenwald](https://www.facebook.com/groups/DW.Archer/)
 
 {% include officer-contacts.html %}

--- a/offices/chatelaine/index.md
+++ b/offices/chatelaine/index.md
@@ -19,7 +19,7 @@ subtitle: What do chatelaines do?
 <li><a href="{{ site.baseurl }}{% link offices/chatelaine/app1-demo-ideas.md %}">Appendix 1: Ideas for Demos </a></li>
 <li><a href="{{ site.baseurl }}{% link offices/chatelaine/app2-orientation.md %}">Appendix 2: Outline for Orientation Meeting </a></li>
 </ul>
-<p>The Barony of Thescorre's <a href="http://www.thescorre.org/literature/adept/index.htm">Adept Handbook: Teaching Through Living History</a> is a useful manual on doing demos. Less demo-oriented, but good for resources for doing classes or repsentations is the <a href="http://groups.yahoo.com/group/SCAteach/">SCAteach mailing list</a>. You can also join the <a href="http://groups.yahoo.com/group/DrachenwaldChatelaines/">Chatelaine's email list</a></p>
+<p>The Barony of Thescorre's <a href="http://www.thescorre.org/literature/adept/index.htm">Adept Handbook: Teaching Through Living History</a> is a useful manual on doing demos. 
 <h2>Information about reporting</h2>
 
 <p>For information on reporting, please read the <a href="{{ site.baseurl }}{% link offices/chatelaine/reporting.md %}">reporting guidelines for chatelaines</a>.</p>


### PR DESCRIPTION
As yahoo groups no longer exist - all references to them have now been removed from the site.