### PR TITLE
Laurel roster: fix blank bullet point for "other online presence"

### DIFF
--- a/peers/laurel/laurel-roster.md
+++ b/peers/laurel/laurel-roster.md
@@ -19,7 +19,7 @@ excerpt: Roster of members
 {% unless item.facebook == "" %} {% assign online = online | push: item.facebook %} {% endunless %} 
 {% unless item.blog == "" %} {% assign online = online | push: item.blog %} {% endunless %} 
 {% unless item.instagram == "" %} {% assign online = online | push: item.instagram %} {% endunless %} 
-{% unless item.other_online_presence == "" %} {% assign online = online | push: item.other_online_presence %} {% endunless %} 
+{% unless item["other-online-presence"] == "" %} {% assign online = online | push: item["other-online-presence"] %} {% endunless %}
 {% unless item.flickr == "" %} {% assign online = online | push: item.flickr %} {% endunless %} 
 
 {% assign affil = "" | split: ', ' %}
@@ -41,7 +41,7 @@ excerpt: Roster of members
 {% unless item.facebook == "" %} * [{{ item.facebook }}]( {{ item.facebook  }} ) {% endunless %}
 {% unless item.instagram == "" %} * [{{ item.instagram }}]( {{ item.instagram  }} ) {% endunless %}
 {% unless item.blog == "" %} * [{{ item.blog }}]( {{ item.blog }} ) {% endunless %}
-{% unless item.other_online_presence == "" %} * [{{ item.other_online_presence }}]( {{ item.other_online_presence }} ) {% endunless %}
+{% unless item["other-online-presence"] == "" %} * [{{ item["other-online-presence"] }}]( {{ item["other-online-presence"] }} ) {% endunless %}
 {% unless item.flickr == "" %} * [{{ item.flickr }}]({{ item.flickr }}) {% endunless %}
 {% endunless %}
 


### PR DESCRIPTION
The JSON contained data with `-` in the name, not `_`.

This fixes #147

~~The long fix would be to normalize these two kind of data at the point of collection, making them the empty string, as the template expected.~~