### PR TITLE
Past events: avoid outputting HTML

### DIFF
--- a/events/pastevents.md
+++ b/events/pastevents.md
@@ -50,7 +50,7 @@ Court report information is limited to those reports submitted via the court rep
 {% for item in pastevents %}
 	{% assign eventslug = item.slug %}
 	{% assign event-court-status = court-status | where: "event_slug", eventslug %}
- 	   <tr data-start-date={{ item.start-date | date: "%s" }}>
+ 	   <tr data-start-date="{{ item.start-date | date: "%s" }}">
 		<td>{{ item.start-date | date: "%-d %b %Y" }} </td>
 		<td>{{ item.host-branch }}</td>
 		<td>{{ item.event-name }}</td>


### PR DESCRIPTION
The quotes around the data- attribute were essential.

Before this change:

![image](https://github.com/drachenwald/drachenwald/assets/211/6060b990-2e9b-4294-a768-2b227c8b35bd)
