### PR TITLE
Move Edit on GitHub links to non-cached footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,12 +15,6 @@
     <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" style="color: #fffb00;" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
   </ul>
 
-  {% if site.github.repository_url %}
-  <ul>
-    <li><a href="{{site.github.repository_url}}/blob/main/{{ page.path }}" class="text-reset"><i class="fab fa-fw fa-github" style="color: #fffb00;" aria-hidden="true"></i> Edit this page on GitHub</a></li>
-    <li><a href="{{site.github.repository_url}}/issues/new?body=Path%3A%20{{ page.url }}%0D" class="text-reset"><i class="fab fa-fw fa-github" style="color: #fffb00;" aria-hidden="true"></i> Open an issue on GitHub</a></li>
-  </ul>
-  {% endif %}
   <ul>
   	<li><a href="https://drachenwald.sca.org/forms">Forms</a></li>
   	<li><a href="https://datastudio.google.com/u/0/reporting/34b2fab2-6092-4574-a11d-f4dfa9adc415/page/lVXNC">Find an officer in the Regnum</a></li>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,0 +1,6 @@
+<div class="page__footer-follow">
+  <ul>
+    <li><a href="{{site.github.repository_url}}/blob/main/{{ page.path }}" class="text-reset"><i class="fab fa-fw fa-github" style="color: #fffb00;" aria-hidden="true"></i> Edit this page on GitHub</a></li>
+    <li><a href="{{site.github.repository_url}}/issues/new?body=Path%3A%20{{ page.url }}%0D" class="text-reset"><i class="fab fa-fw fa-github" style="color: #fffb00;" aria-hidden="true"></i> Open an issue on GitHub</a></li>
+  </ul>
+</div>


### PR DESCRIPTION
This PR changes the footer where the links to "Edit this page on GitHub" are placed. With that, the issue that "the same path and URL are offered in the links" is fixed.

## Details

This PR moves those links to a "dynamic footer", which is rendered _before_ the cached footer. That's a part of Jekyll theme we are using.

A small side-effect, which I think we should accept, is that the custom, dynamic content is rendered before the fixed one.

The cached footer would always have the same page.path, page.url parameters. The "footer/custom.html" allows customization, with dynamic data.

## More details

<details>

The inclusion in the theme:
https://github.com/mmistakes/minimal-mistakes/blob/93022d6432f277eb5d83677fa50e4120f1281b04/_layouts/default.html#L29


</details>

Fixes #71