### PR TITLE
main.scss: add a centered-and-max-600 CSS class

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -92,10 +92,19 @@ $type-size-8: 0.7em !default; // ~10px
   padding: 5px;
 }
 
-.centered-and-max-800 {
+.margin-left-and-right-auto {
   margin-left: auto;
   margin-right: auto;
+}
+
+.centered-and-max-800 {
+  @extend .margin-left-and-right-auto;
   max-width: 800px;
+}
+
+.centered-and-max-600 {
+  @extend .margin-left-and-right-auto;
+  max-width: 600px;
 }
 
 .pagination {


### PR DESCRIPTION
This PR adds a new CSS class to slightly simplify layout work in the content pages.

We have in place a 800px and centered CSS class. But: There are pages which also manual styling to get "600px centered".

This change extracts the centeredness via auto margins to a CSS class for utility usage, and defines a 600px wide class, too.

## Details

I used https://sass-lang.com/playground/#eJwzNNTLTSxKz8zTzUlNK9FNzEvRLcpMzwCySkvyFaq5FBSQpK0UQKLWCEGwUphoLReXXnJqXklqUWoK2KDcxApdCwMDsCkOqRUlqXkpCnhsg5hboVuemVKSYaUA1FlQgcNUM7JNNYOZCgBNNFFj to play with the SCSS.