### PR TITLE
Gemfile: refer always to Jekyll on a released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,7 @@ gem "faraday-retry", "~> 2.2"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-# Fix specifically for Michael's local environment
-# gem "jekyll", "4.3.3"
-gem "jekyll", github: "jekyll/jekyll" # LOCKED: Since https://github.com/drachenwald/drachenwald/pull/132, we use an unreleased version of Jekyll. When https://github.com/jekyll/jekyll/pull/9392 is released in a new Jekyll version, use that instead of having `github: "jekyll/jekyll"`.
+gem "jekyll", ">= 4.3.3"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minimal-mistakes-jekyll"


### PR DESCRIPTION
Now that the issues that we waited for being released have been released, we can go back to using a RubyGems.org-served regular version, instead of a GitHub.com git-served version.