### PR TITLE
Add SCA Österreich to thisisdrachenwald_feedlist.json

### DIFF
--- a/_data/thisisdrachenwald_feedlist.json
+++ b/_data/thisisdrachenwald_feedlist.json
@@ -462,5 +462,13 @@
     "merge": false,
     "showMedia": true,
     "type": "blog"
+  },
+  {
+    "url": "https://sca-austria.at/category/schwertkampf/feed/",
+    "name": "SCA Österreich - Schwertkampf",
+    "link": "https://sca-austria.at/category/schwertkampf/",
+    "merge": false,
+    "showMedia": true,
+    "type": "blog"
   }
 ]


### PR DESCRIPTION
This is a PR that adds the requested blog feed to This is Drachenwald. Fixes #188.