### PR TITLE
Groups index page: Format canton headings

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -111,6 +111,10 @@ $type-size-8: 0.7em !default; // ~10px
   text-align: center;
 }
 
+.display-inline-block {
+  display: inline-block;
+}
+
 .pagination {
   display: inline-block;
 }

--- a/groups/index.html
+++ b/groups/index.html
@@ -35,8 +35,9 @@ title: Where we are
 		{% assign grandchild_branches = groups | where: "parent", child.group %}	
 <ul>
 		{% for grandchild in grandchild_branches  %}	
-		<li><b><h4 style="font-size: 1.15em;">{{ grandchild.status }} of {{ grandchild.group }}</h4></b>
-		{% include branch_details.md branch=grandchild %}		</li>
+		<li><h4 class="display-inline-block" style="font-size: 1.15em;">{{ grandchild.status }} of {{ grandchild.group }}</h4>
+			<div>
+		{% include branch_details.md branch=grandchild %}</div>		</li>
 
 	{% endfor %}
 		</ul>


### PR DESCRIPTION
This avoids extra newlines shown before the names of cantons. This displays the Knights Crossing cantons correctly.

Example fixed:

<img width="708" alt="bild" src="https://github.com/user-attachments/assets/27708977-e72d-48e5-bb83-878a2a2cef5c" />

Example before:

<img width="717" alt="bild" src="https://github.com/user-attachments/assets/2a80c4e3-0834-4bb7-aac0-1d275f5c2cce" />
