### PR TITLE
Fixed Orders of Merit heading level

### DIFF
--- a/offices/herald/drachenwaldawardsorders.md
+++ b/offices/herald/drachenwaldawardsorders.md
@@ -103,7 +103,7 @@ The badge of this order is ‘(Fieldless) A wing terminating in a hand gules sus
 
 
 
-## Orders of Merit
+# Orders of Merit
 Drachenwald has three orders that confer an Award of Arms upon the recipient, if the receiver does not already hold one (as heralds say, ‘are armigerous’).
 
 ## Orden Des Lindquistringes  


### PR DESCRIPTION
Fixed Orders of Merit heading level, as it was showing as a heading at the same level as the lower ones. See https://github.com/drachenwald/drachenwald/issues/211