### PR TITLE
Calendar: configure localevents="none"

### DIFF
--- a/events/calendar/index.md
+++ b/events/calendar/index.md
@@ -8,6 +8,7 @@ redirect_from:
 
 {% if jekyll.environment == "production" %}
 <div  id="calendar"
+      localevents="none"
       legend="true"
       links="local"
       bidlinks="true"
@@ -15,6 +16,7 @@ redirect_from:
 <script type="text/javascript" src="https://scripts.drachenwald.sca.org/calendar/v3.0/calendar.js"></script>
 {% elsif jekyll.environment == "staging" %}
 <div  id="calendar"
+      localevents="none"  
       legend="true"
       links="local"
       bidlinks="true"
@@ -22,6 +24,7 @@ redirect_from:
 <script type="text/javascript" src="https://sca-drachenwald.gitlab.io/events-calendar/calendar.js"></script>
 {% elsif jekyll.environment == "development" %}
 <div  id="calendar"
+      localevents="none"
       legend="true"
       links="local"
       bidlinks="true"


### PR DESCRIPTION
In order not to show "monthly sewing night at Attemark" in the Drachenwald kingdom calendar, this is the configuration option we can use.

[Docs for the Calendar](https://gitlab.com/sca-drachenwald/events-calendar)