### PR TITLE
branch_details.md: Treat Discord as "has_online"

### DIFF
--- a/_includes/branch_details.md
+++ b/_includes/branch_details.md
@@ -3,7 +3,7 @@
 
 {% assign has_online = false %}
 
-{% if group.website != "" or group.facebook-page != "" or group.facebook != "" or group.twitter != "" or group.instagram != "" or group.youtube != "" %}
+{% if group.website != "" or group.facebook-page != "" or group.facebook != "" or group.twitter != "" or group.instagram != "" or group.discord != "" or group.youtube != "" %}
     {% assign has_online = true %}
 {% endif %}
 


### PR DESCRIPTION
This fixes an issue which afflicted groups that had no other online presence than Discord.

With this change, a group having only Discord now shows the `Online: ` prefix on the line that shows the Discord link.